### PR TITLE
Remove data bag symlink

### DIFF
--- a/spec/support/fixtures/data_bags/rundeck_projects
+++ b/spec/support/fixtures/data_bags/rundeck_projects
@@ -1,1 +1,0 @@
-../../../../test/integration/default/data_bags/rundeck_projects

--- a/spec/support/fixtures/data_bags/rundeck_projects/localhost.json
+++ b/spec/support/fixtures/data_bags/rundeck_projects/localhost.json
@@ -1,0 +1,8 @@
+{
+  "id": "localhost",
+  "hostname": "ipaddress",
+  "username": "rundeck",
+  "pattern": "*:*",
+  "description": "These instances are tied to the dev-systems project in Rundeck.",
+  "old_style": true
+}


### PR DESCRIPTION
### Description

There is currently a symlink of `spec/support/fixtures/data_bags/rundeck_projects` to `test/integration/default/data_bags/rundeck_projects`. This seemingly breaks using the cookbook in wrapper cookbooks as it causes Test Kitchen to error out.

I've replaced it with a single data bag item which fixes the issue and specs pass.

```
     Transferring files to <rundeck-server-debian-88>
/opt/chefdk/embedded/lib/ruby/gems/2.4.0/gems/net-scp-1.2.1/lib/net/scp.rb:365:in `block (3 levels) in start_command': SCP did not finish successfully ():  (Net::SCP::Error)
```
```
       Transferring files to <rundeck-server-debian-88>
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Failed to complete #converge action: [No such file or directory @ rb_file_s_stat - /var/folders/rr/v62ptbjx5wqc7ms_h5lbtwg80000gn/T/rundeck-server-debian-88-sandbox-20170802-89305-r2wo9a/cookbooks/rundeck/spec/support/fixtures/data_bags/rundeck_projects] on rundeck-server-debian-88
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

### Issues resolved
#162 
Related: https://github.com/sous-chefs/rundeck/commit/94f3138b6f2009a89e60378d6b6465ef36fe3456

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable