### PR TITLE
Remove dependency on java-libraries

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,6 @@ depends          'runit'
 depends          'sudo'
 depends          'java'
 depends          'apache2'
-depends          'java-libraries'
 depends          'build-essential'
 
 %w(debian ubuntu centos suse fedora redhat freebsd windows scientific oracle amazon mac_os_x).each do |os|


### PR DESCRIPTION
### Description

If you are using the Rundeck cookbook and the Java cookbook at the same time, you get `Chef::Exceptions::ProviderNotFound` when trying to use the `java_certificate` resource. This is because both the `java` and the `java-libraries` cookbook define a resource and provider with that name. 

As the `java-libraries` cookbook is now obsolete, removing it from the dependencies should have no effect.

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable