### PR TITLE
Obvious fix

### DIFF
--- a/templates/default/framework.properties.erb
+++ b/templates/default/framework.properties.erb
@@ -107,6 +107,6 @@ framework.winrm-timeout = <%= @windows_winrm_timeout %>
 
 
 # API Tokens File
-<% unless @tokensfile.nil? -%>
+<% unless @tokens_file.nil? -%>
 rundeck.tokens.file = <%= @tokensfile %>
 <% end -%>


### PR DESCRIPTION
- Fix framework.properties.erb template to correctly use `tokens_file`

Signed-off-by: Brian Menges <mengesb@gmail.com>

### Description
Fix framework.properties template

### Issues Resolved
Addresses #201 

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable