### PR TITLE
Obvious fix - private_key

### DIFF
--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -65,7 +65,7 @@ property :mail_password, String, sensitive: true
 property :mail_port, String
 property :mail_user, String
 property :port, Integer, default: 4440
-property :private_key, [nil, String], default: nil,  sensitive: true
+property :private_key, [nil, String], default: nil, sensitive: true
 property :quartz_threadPoolCount, Integer, default: 10
 property :rdbms_dbname, String
 property :rdbms_dialect, String

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -65,7 +65,7 @@ property :mail_password, String, sensitive: true
 property :mail_port, String
 property :mail_user, String
 property :port, Integer, default: 4440
-property :private_key, String, sensitive: true
+property :private_key, [nil, String], default: nil,  sensitive: true
 property :quartz_threadPoolCount, Integer, default: 10
 property :rdbms_dbname, String
 property :rdbms_dialect, String
@@ -174,7 +174,8 @@ action :install do
     mode '0600'
     backup false
     content new_resource.private_key
-    only_if { new_resource.private_key }
+    sensitive true
+    not_if { new_resource.private_key.nil? }
     notifies (new_resource.restart_on_config_change ? :restart : :nothing), 'service[rundeckd]', :delayed
   end
 


### PR DESCRIPTION
### Description

- Allow `private_key` to be nil and default to nil
- Enforce `private_key` as a sensitive resource
- Modify `only_if` to `not_if` and test for nil

Signed-off-by: Brian Menges <mengesb@gmail.com>

### Issues Resolved

#203 

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable