### PR TITLE
Remove deprecated OpenJDK 8 option MaxPermSize

### DIFF
--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -35,7 +35,7 @@ property :grails_port, Integer, default: lazy { use_ssl ? 443 : 80 }
 property :grails_server_url, String, default: lazy { "#{use_inbuilt_ssl ? 'https' : 'http'}://#{hostname}" }
 property :hostname, String, default: "rundeck.#{node['domain']}"
 property :jaas, String, default: 'internal'
-property :jvm_mem, String, default: ' -XX:MaxPermSize=256m -Xmx1024m -Xms256m'
+property :jvm_mem, String, default: ' -Xmx1024m -Xms256m'
 property :rundeckgroup, String,
          default: 'rundeck' # 'The user account that rundeck will operate as'
 property :rundeckuser, String,


### PR DESCRIPTION
### Description

- Remove deprecated OpenJDK 8 option MaxPermSize

Signed-off-by: Brian Menges <mengesb@gmail.com>

### Issues Resolved

#205 

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable