### PR TITLE
Change tokensfile var name in framework.properties template

### DIFF
--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -211,7 +211,7 @@ action :install do
       configdir: new_resource.configdir,
       custom_rundeck_config: new_resource.custom_rundeck_config,
       grails_port: new_resource.grails_port,
-      grails_server_url:  new_resource.grails_server_url,
+      grails_server_url: new_resource.grails_server_url,
       log_level: new_resource.log_level,
       mail_email: new_resource.mail_email,
       mail_host: new_resource.mail_host,

--- a/templates/default/framework.properties.erb
+++ b/templates/default/framework.properties.erb
@@ -108,5 +108,5 @@ framework.winrm-timeout = <%= @windows_winrm_timeout %>
 
 # API Tokens File
 <% unless @tokens_file.nil? -%>
-rundeck.tokens.file = <%= @tokensfile %>
+rundeck.tokens.file = <%= @tokens_file %>
 <% end -%>


### PR DESCRIPTION
### Description

Changes `tokensfile` to `tokens_file` as first one does not exist.  

### Issues Resolved

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable