### PR TITLE
Added missing supplimental roles for LDAP users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the Rundeck cookbook.
 
 * Fixes password quotation in rd config
 * Fixes Supermarket foodcritic errors
+* Added missing ldap_supplimentalroles
 
 ## 5.0.2
 

--- a/documentation/resource_server_install.md
+++ b/documentation/resource_server_install.md
@@ -43,6 +43,7 @@ server_install 'rundeck' do
   ldap_rolememberattribute      String # LDAP attribute name that would contain the users DN
   ldap_roleobjectclass          String # LDAP object class for group
   ldap_roleprefix               String # Prefix string to remove from role names before returning to the application
+  ldap_supplementalroles        String # Comma separated list of roles that the ldap user will assume by default "role1,role2,...". Default: nil
   ldap_cachedurationmillis      String # Duration in milliseconds of the cache of an authorization
   ldap_reportstatistics         String # If true, output cache statistics to the log
   log_level                     %w(ERR WARN INFO VERBOSE DEBUG) # Debug level for rundeck (ERR,WARN,INFO,VERBOSE,DEBUG), default INFO

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -57,6 +57,7 @@ property :ldap_roleobjectclass, String
 property :ldap_roleprefix, String
 property :ldap_cachedurationmillis, String
 property :ldap_reportstatistics, String
+property :ldap_supplementalroles, String
 property :log_level, %w(ERR WARN INFO VERBOSE DEBUG), default: 'INFO'
 property :mail_email, String
 property :mail_enable, [true, false], default: false
@@ -298,6 +299,7 @@ action :install do
       ldap_roleprefix: new_resource.ldap_roleprefix,
       ldap_cachedurationmillis: new_resource.ldap_cachedurationmillis,
       ldap_reportstatistics: new_resource.ldap_reportstatistics,
+      ldap_supplementalroles: new_resource.ldap_supplementalroles,
       rundeck_version: new_resource.version
     )
     notifies (new_resource.restart_on_config_change ? :restart : :nothing), 'service[rundeckd]', :delayed


### PR DESCRIPTION
### Description

Added the missing option for ldap supplemental role. The active directory template file already had that option.

### Issues Resolved

### Contribution Check List

- [ ] All tests pass.
- [x] New functionality includes testing. - NA
- [x] New functionality has been documented in the README if applicable