### PR TITLE
Cookstyle fixes

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -25,13 +25,13 @@ def test_changes?
   false
 end
 
-fail 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
+raise 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
 
 warn 'This is a big Pull Request.' if git.lines_of_code > 400
 
 # Require a CHANGELOG entry for non-test changes.
 if !git.modified_files.include?('CHANGELOG.md') && code_changes?
-  fail 'Please include a CHANGELOG entry.'
+  raise 'Please include a CHANGELOG entry.'
 end
 
 # A sanity check for tests.

--- a/resources/apache.rb
+++ b/resources/apache.rb
@@ -106,7 +106,7 @@ action :install do
     path "#{apache_dir}/sites-available/rundeck.conf"
     source 'rundeck.conf.erb'
     cookbook 'rundeck'
-    mode 00644
+    mode '644'
     owner 'root'
     group 'root'
     variables(

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: rundeck
+# Cookbook:: rundeck
 # Resource:: plugin
 #
-# Copyright 2012, Peter Crossley
+# Copyright:: 2012, Peter Crossley
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
raise vs.  fail
mode as a string not an int
chef style headers

Signed-off-by: Tim Smith <tsmith@chef.io>