### PR TITLE
Swap java recipe for resource

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
         os:
           - "centos-7"
           - "debian-9"
-          - "ubuntu-1604"
           - "ubuntu-1804"
+          - "ubuntu-2004"
         suite:
           - "server-install"
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file is used to list changes made in each version of the Rundeck cookbook.
 
 ## Unreleased
+- Fix rundeck_dependices to use java openjdk resource instead of recipe that causes errors
 
 ## 5.1.1 - *2020-12-02*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file is used to list changes made in each version of the Rundeck cookbook.
 
 ## Unreleased
-- Fix rundeck_dependices to use java openjdk resource instead of recipe that causes errors
+- Fix rundeck_dependencies to use java openjdk resource instead of recipe that causes errors
 
 ## 5.1.1 - *2020-12-02*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the Rundeck cookbook.
 ## Unreleased
 
 - Fix rundeck_dependencies to use java openjdk resource instead of recipe that causes errors
+- put a limit on the java cookbook version to 8 or greater
 
 ## 5.1.1 - *2020-12-02*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file is used to list changes made in each version of the Rundeck cookbook.
 
 ## Unreleased
+
 - Fix rundeck_dependencies to use java openjdk resource instead of recipe that causes errors
 
 ## 5.1.1 - *2020-12-02*

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -26,16 +26,16 @@ platforms:
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
 
-  - name: ubuntu-16.04
-    driver:
-      image: dokken/ubuntu-16.04
-      pid_one_command: /sbin/init
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+
+  - name: ubuntu-20.04
+    driver:
+      image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -22,11 +22,11 @@ platforms:
     lifecycle:
       post_create:
         - remote: sudo apt update
-  - name: ubuntu-16.04
+  - name: ubuntu-18.04
     lifecycle:
       post_create:
         - remote: sudo apt update
-  - name: ubuntu-18.04
+  - name: ubuntu-20.04
     lifecycle:
       post_create:
         - remote: sudo apt update

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
 description      'Installs and configures Rundeck 2.x'
 version          '5.1.1'
-depends          'java'
+depends          'java', '>= 8.0.0'
 depends          'apache2', '~> 7.0.0'
 
 %w(ubuntu centos fedora redhat scientific oracle).each do |os|

--- a/resources/dependencies.rb
+++ b/resources/dependencies.rb
@@ -17,5 +17,5 @@
 #
 
 action :install do
-  openjdk_install '8'
+  adoptopenjdk_install '8'
 end

--- a/resources/dependencies.rb
+++ b/resources/dependencies.rb
@@ -17,6 +17,7 @@
 #
 
 action :install do
-  node.default['java']['jdk_version'] = '8'
-  include_recipe 'java'
+  openjdk_install '8' do
+    action :install
+  end
 end

--- a/resources/dependencies.rb
+++ b/resources/dependencies.rb
@@ -17,7 +17,5 @@
 #
 
 action :install do
-  openjdk_install '8' do
-    action :install
-  end
+  openjdk_install '8'
 end


### PR DESCRIPTION
# Description

rundeck_dependencies was erroring because the java cookbook throws an error when trying to use recipes. Swapped out to the openjdk resource since that is supposed to be the default of the java cookbook.  

## Issues Resolved

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
