### PR TITLE
feat: install Java via temurin_package_install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,15 @@ jobs:
       matrix:
         os:
           - almalinux-8
-          - amazonlinux-2
-          - debian-10
-          # - debian-11 TODO: Disabled due to service not starting
-          - centos-7
-          - centos-stream-8
+          - almalinux-9
+          - centos-stream-9
           - fedora-latest
-          - ubuntu-1804
-          - ubuntu-2004
+          - oraclelinux-8
+          - oraclelinux-9
           - rockylinux-8
+          - rockylinux-9
+          - ubuntu-2204
+          - ubuntu-2404
         suite: [default]
       fail-fast: false
 

--- a/resources/dependencies.rb
+++ b/resources/dependencies.rb
@@ -19,5 +19,5 @@
 unified_mode true
 
 action :install do
-  adoptopenjdk_install '8'
+  temurin_package_install '8'
 end


### PR DESCRIPTION
## Problem

Every integration converge fails:

```
NoMethodError: undefined method `adoptopenjdk_install'
  resources/dependencies.rb:22
```

AdoptOpenJDK was rebranded to Eclipse Temurin and the java cookbook dropped `adoptopenjdk_install`. v15 provides `temurin_package_install`, `openjdk_pkg_install`, `openjdk_source_install` and `corretto_install`.

This also explains the apparent out-of-memory kills. While reporting the `NoMethodError`, Chef's error inspector serialised the whole resource object graph — about **3.7 GB** of output — and the runner was killed. The `exit 137` was a symptom, not an independent memory problem.

## Fix

`version` is the name property on all the java resources, so `temurin_package_install '8'` is a direct swap and keeps using the Adoptium packages this cookbook already relied on.

## Also: CI matrix realignment

Six of the nine matrix platforms had no matching Kitchen instance, so those jobs failed before converging:

```
No instances for regex `default-centos-7', try running `kitchen list'
```

`amazonlinux-2`, `centos-7`, `centos-stream-8`, `debian-10` and `ubuntu-1804` are absent from `kitchen.dokken.yml` and all are EOL. Matrix now matches the platforms Kitchen actually defines.

## Verification

Locally with Cinc Workstation: 4 examples, 0 failures; cookstyle clean on 22 files. Integration is the real test here — CI will show whether the converge now completes.

## Related

Stacked conceptually on #347 (Policyfile migration + required-check fixes), but touches different files, so the two do not conflict.